### PR TITLE
Fix build on FreeBSD/DragonFly

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -10,6 +10,9 @@ fn configure(build: &mut cc::Build) -> &mut cc::Build {
         build.define("_GNU_SOURCE", None);
         build.define("HAVE_ENDIAN_H", None);
     }
+    if cfg!(any(target_os = "freebsd", target_os = "dragonfly")) {
+        build.define("PTHREAD_SETAFFINITY_IN_NP_HEADER", None);
+    }
     if cfg!(target_os = "windows") {
         build.define("_USE_MATH_DEFINES", None);
     } else {


### PR DESCRIPTION
This fixes

```
cargo:warning=glsl-optimizer/src/util/u_thread.h:83:4: error: use of undeclared identifier 'pthread_set_name_np'; did you mean 'pthread_setname_np'?
```

(encountered when building Firefox)