### PR TITLE
build: Explicitly avoid including mozilla-config.h in gecko builds.

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -18,6 +18,8 @@ fn configure(build: &mut cc::Build) -> &mut cc::Build {
         build.define("HAVE_TIMESPEC_GET", None);
     }
 
+    // Avoid including mozilla-config.h in Gecko builds
+    build.define("MOZILLA_CONFIG_H", None);
     // Avoid using e.g. moz_malloc in Gecko builds.
     build.define("MOZ_INCLUDE_MOZALLOC_H", None);
     // Avoid using e.g. mozalloc_abort in Gecko builds.


### PR DESCRIPTION
This happens already right now because of [1] but we want to remove that, see mozilla bug 1992321 [2].

[1]: https://searchfox.org/firefox-main/rev/e613f4df351a21871cfeadf7d5b4043ffad157b1/config/makefiles/rust.mk#200
[2]: https://bugzil.la/1992321