### PR TITLE
 fix: Rename float16_t to mesa_float16_t to avoid ARM NEON collision on ARM64 Windows

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "glsl-optimizer"]
 	path = glsl-optimizer
-	url = https://github.com/jamienicol/glsl-optimizer.git
+	url = https://github.com/npiesco/glsl-optimizer.git

--- a/tests/arm64_float16_collision_test.cpp
+++ b/tests/arm64_float16_collision_test.cpp
@@ -1,0 +1,31 @@
+﻿// Test that mesa_float16_t doesn't conflict with ARM NEON's float16_t
+// This simulates the ARM64 Windows environment where arm_fp16.h defines float16_t
+
+// Simulate ARM NEON's float16_t typedef (as defined in arm_fp16.h on ARM64)
+#ifdef _M_ARM64
+// On real ARM64 Windows, this comes from arm_fp16.h
+// typedef __fp16 float16_t;
+#endif
+
+// For testing purposes, we define a conflicting float16_t to verify our fix works
+typedef unsigned short float16_t;
+
+// Now include our header - this should NOT conflict because we use mesa_float16_t
+#include "glsl-optimizer/src/util/half_float.h"
+
+// Verify mesa_float16_t is usable
+void test_mesa_float16_t() {
+#ifdef __cplusplus
+    mesa_float16_t a(1.0f);
+    mesa_float16_t b(2.0);
+    mesa_float16_t c((uint16_t)0x3c00);
+    mesa_float16_t one = mesa_float16_t::one();
+    mesa_float16_t zero = mesa_float16_t::zero();
+    (void)a; (void)b; (void)c; (void)one; (void)zero;
+#endif
+}
+
+int main() {
+    test_mesa_float16_t();
+    return 0;
+}


### PR DESCRIPTION
This PR fixes build failure on ARM64 Windows (aarch64-pc-windows-msvc) caused by naming collision between struct `float16_t` in `half_float.h` and ARM NEON's `float16_t` typedef from `arm_fp16.h`.

**Changes (Compatibility Fix):**
Renamed struct `float16_t` to struct `mesa_float16_t` in `glsl-optimizer/src/util/half_float.h` to avoid conflict with ARM NEON intrinsics.

**Regression Test:**
Added `tests/arm64_float16_collision_test.cpp` - compile-time test that verifies `mesa_float16_t` does not conflict with typedef'd `float16_t`, on ARM64 Windows when `arm_fp16.h` is included.

**Submodule Update:**
Updated glsl-optimizer submodule pointer to include above fix (2ec7cc11d9e --> 047896ab9de).

**Note:** Submodule temporarily points to my fork (https://github.com/npiesco/glsl-optimizer) until upstream PR is merged: https://github.com/jamienicol/glsl-optimizer/pull/14

Once #14 is merged, can update point back to jamienicol/glsl-optimizer.